### PR TITLE
Arreglados Warnings Por Cambiar Variable

### DIFF
--- a/src/Test.js
+++ b/src/Test.js
@@ -16,7 +16,7 @@ class Test extends Component {
 
     handleClick() {
         setTimeout(()=> {
-            this.setState({ examen: ++this.state.examen });
+            this.setState({ examen: this.state.examen + 1});
             this.setterTamanio();
 
             if (this.state.examen > 10) {
@@ -37,9 +37,9 @@ class Test extends Component {
               <Ejercicio key={`ejercicio-${this.state.examen}`} tamanio={this.state.size} alTerminar={(acierto) => {
                   this.handleClick();
                   if(acierto){
-                      this.setState({respuestaBien: ++this.state.respuestaBien})
+                      this.setState({respuestaBien: this.state.respuestaBien  + 1})
                   } else {
-                      this.setState({respuestaMal: ++this.state.respuestaMal})
+                      this.setState({respuestaMal: this.state.respuestaMal  + 1})
                   }
               }}/>
           </div>


### PR DESCRIPTION
## Problema

La manera de modificar variables del estado en React es a través del setState.
De esta manera el framework se entera de hubo un cambio y actua en consecuencia.

## Solución

Al estar haciendo la suma con el operador `++` la variable cambiaba de valor antes de usar el `setState`.
Cambie las sumas para que no cambien el valor de la variable hasta que se haga el `setState`