### PR TITLE
Convertir a PWA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ludo-candys",
+  "name": "nodix",
   "version": "0.1.0",
   "engines": {
     "node": "8.11.3",

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="theme-color" content="#F9CA47">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="theme-color" content="#000000">
+    <meta name="theme-color" content="#F9CA47">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
@@ -27,7 +27,7 @@
     </noscript>
     <header>
       <div class="logo-container">
-        <img align="center" class="logo" src="nodix-logo.png" alt="logo de nodix">
+        <img align="center" class="logo" src="%PUBLIC_URL%/nodix-logo.png" alt="logo de nodix">
       </div>
     </header>
     <div id="root"></div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,6 +11,6 @@
   ],
   "start_url": "./index.html",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#F9CA47",
   "orientation": "portrait"
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,6 +7,11 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
+    },
+    {
+      "src": "nodix-logo.png",
+      "sizes": "192x192 512x512",
+      "type": "image/png"
     }
   ],
   "start_url": "./index.html",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Nodix",
   "short_name": "Nodix",
-  "background_color": "#F9CA47",
+  "background_color": "#FFFFFF",
   "icons": [
     {
       "src": "favicon.ico",
@@ -16,6 +16,6 @@
   ],
   "start_url": "./index.html",
   "display": "standalone",
-  "theme_color": "#F9CA47",
+  "theme_color": "#FFFFFF",
   "orientation": "portrait"
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,7 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "name": "Nodix",
+  "short_name": "Nodix",
+  "background_color": "#F9CA47",
   "icons": [
     {
       "src": "favicon.ico",
@@ -11,5 +12,5 @@
   "start_url": "./index.html",
   "display": "standalone",
   "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "orientation": "portrait"
 }

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,2 @@
+<h1>Sin conexión a internet!</h1>
+<h2>No es posible conectarse a la red, el modo sin conexión fue activado.</h2>

--- a/static.json
+++ b/static.json
@@ -1,0 +1,7 @@
+{
+  "root": "build/",
+  "routes": {
+    "/**": "index.html"
+  },
+  "https_only": true
+}


### PR DESCRIPTION
Convierte a nodix en una progressive web app. Esto significa que al ingresar a la app web en un celular, el mismo nos permitira instalar Nodix como una aplicación en el celular, esta funcionalidad nos permite que la aplicación siga funcionando incluso si el usuario no tiene acceso a internet!

Ademas, arregla un bug al importar el logo en el encabezado de la app.

